### PR TITLE
API 3.0.0 support

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: FaceLogin
 main: Muqsit\FaceLogin
-api: [2.0.0, 3.0.0, 3.0.0-ALPHA4, 3.0.0-ALPHA5, 3.0.0-ALPHA6, 3.0.0-ALPHA67]
-version: 1.0.0
+api: [3.0.0]
+version: 1.1.0
 author: Muqsit
 permissions:
   facelogin.show:

--- a/src/Muqsit/FaceLogin.php
+++ b/src/Muqsit/FaceLogin.php
@@ -3,7 +3,7 @@
 *
 * Copyright (C) 2017 Muqsit Rayyan
 *
-*    ___                __             _  
+*    ___                __             _
 *   / __\_ _  ___ ___  / /  ___   __ _(_)_ __
 *  / _\/ _` |/ __/ _ \/ /  / _ \ / _` | | '_ \
 * / / | (_| | (_|  __/ /__| (_) | (_| | | | | |
@@ -68,7 +68,7 @@ class FaceLogin extends PluginBase implements Listener {
 
     public function sendFace(Player $player, array $messages = null)
     {
-        $this->getServer()->getScheduler()->scheduleAsyncTask(new SendPlayerFaceTask($player->getName(), $player->getSkinData(), $messages ?? $this->messages));
+        $this->getServer()->getAsyncPool()->submitTask(new SendPlayerFaceTask($player->getName(), $player->getSkin()->getSkinData(), $messages ?? $this->messages));
     }
 
     public function onJoin(PlayerJoinEvent $event)


### PR DESCRIPTION
A few changes to make the plugin run on the current api of pmmp.

-> use the async pool of the server directly
-> use the skin instance of the player to get the skin data
-> bumped api version and plugin minor version

Kind of related to #6 , however this pr aims for a newer api version.