### PR TITLE
128x128 skins and therefore 16x16 faces support

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: FaceLogin
 main: Muqsit\FaceLogin
-api: [2.0.0, 3.0.0, 3.0.0-ALPHA4, 3.0.0-ALPHA5, 3.0.0-ALPHA6, 3.0.0-ALPHA67]
-version: 1.0.0
+api: [3.0.0]
+version: 1.1.0
 author: Muqsit
 permissions:
   facelogin.show:

--- a/src/Muqsit/FaceLogin.php
+++ b/src/Muqsit/FaceLogin.php
@@ -3,7 +3,7 @@
 *
 * Copyright (C) 2017 Muqsit Rayyan
 *
-*    ___                __             _  
+*    ___                __             _
 *   / __\_ _  ___ ___  / /  ___   __ _(_)_ __
 *  / _\/ _` |/ __/ _ \/ /  / _ \ / _` | | '_ \
 * / / | (_| | (_|  __/ /__| (_) | (_| | | | | |
@@ -68,7 +68,7 @@ class FaceLogin extends PluginBase implements Listener {
 
     public function sendFace(Player $player, array $messages = null)
     {
-        $this->getServer()->getScheduler()->scheduleAsyncTask(new SendPlayerFaceTask($player->getName(), $player->getSkinData(), $messages ?? $this->messages));
+        $this->getServer()->getAsyncPool()->submitTask(new SendPlayerFaceTask($player->getName(), $player->getSkin()->getSkinData(), $messages ?? $this->messages));
     }
 
     public function onJoin(PlayerJoinEvent $event)

--- a/src/Muqsit/SendPlayerFaceTask.php
+++ b/src/Muqsit/SendPlayerFaceTask.php
@@ -121,32 +121,32 @@ class SendPlayerFaceTask extends AsyncTask {
 
         $skin = substr($this->skindata, ($pos = ($width * $maxX * 4)) - 4, $pos);
 
-	for($y = 0; $y < $maxY; ++$y){
-		for($x = 1; $x < $maxX + 1; ++$x){
-			if(!isset($strArray[$y])){
-				$strArray[$y] = "";
-			}
-			// layer 1
-			$key = (($width * $y) + $maxX + $x) * 4;
+        for($y = 0; $y < $maxY; ++$y){
+            for($x = 1; $x < $maxX + 1; ++$x){
+                if(!isset($strArray[$y])){
+                    $strArray[$y] = "";
+                }
+                // layer 1
+                $key = (($width * $y) + $maxX + $x) * 4;
 
-			// layer 2
-			$key2 = (($width * $y) + $maxX + $x + $uv) * 4;
-			$a = ord($skin{$key2 + 3});
+                // layer 2
+                $key2 = (($width * $y) + $maxX + $x + $uv) * 4;
+                $a = ord($skin{$key2 + 3});
 
-			if($a >= 127){ // if layer 2 pixel is opaque enough, use it instead.
-				$r = ord($skin{$key2});
-				$g = ord($skin{$key2 + 1});
-				$b = ord($skin{$key2 + 2});
-			} else {
-				$r = ord($skin{$key});
-				$g = ord($skin{$key + 1});
-				$b = ord($skin{$key + 2});
-			}
+                if($a >= 127){ // if layer 2 pixel is opaque enough, use it instead.
+                    $r = ord($skin{$key2});
+                    $g = ord($skin{$key2 + 1});
+                    $b = ord($skin{$key2 + 2});
+                } else {
+                    $r = ord($skin{$key});
+                    $g = ord($skin{$key + 1});
+                    $b = ord($skin{$key + 2});
+                }
 
-			$format = $this->rgbToTextFormat($r, $g, $b);
-			$strArray[$y] .= $format . $symbol;
-		}
-	}
+                $format = $this->rgbToTextFormat($r, $g, $b);
+                $strArray[$y] .= $format . $symbol;
+            }
+        }
         
         foreach($this->messages as $k => $v){
             $strArray[$k - 1] = $strArray[$k - 1]." ".str_replace("{NAME}", $this->player, $v);

--- a/src/Muqsit/SendPlayerFaceTask.php
+++ b/src/Muqsit/SendPlayerFaceTask.php
@@ -109,14 +109,14 @@ class SendPlayerFaceTask extends AsyncTask {
                 $maxX = $maxY = 8;
 
                 $width = 64;
-                $layer2Offset = 32;
+                $uv = 32;
                 break;
 
             case 65536:
                 $maxX = $maxY = 16;
 
                 $width = 128;
-                $layer2Offset = 64;
+                $uv = 64;
         }
 
         $skin = substr($this->skindata, ($pos = ($width * $maxX * 4)) - 4, $pos);
@@ -130,7 +130,7 @@ class SendPlayerFaceTask extends AsyncTask {
 			$key = (($width * $y) + $maxX + $x) * 4;
 
 			// layer 2
-			$key2 = (($width * $y) + $maxX + $x + $layer2Offset) * 4;
+			$key2 = (($width * $y) + $maxX + $x + $uv) * 4;
 			$a = ord($skin{$key2 + 3});
 
 			if($a >= 127){ // if layer 2 pixel is opaque enough, use it instead.

--- a/src/Muqsit/SendPlayerFaceTask.php
+++ b/src/Muqsit/SendPlayerFaceTask.php
@@ -102,17 +102,35 @@ class SendPlayerFaceTask extends AsyncTask {
     {
         $symbol = hex2bin(self::HEX_SYMBOL);
         $strArray = [];
-        $skin = substr($this->skindata, ($pos = (64 * 8 * 4)) - 4, $pos);
-	for($y = 0; $y < 8; ++$y){
-		for($x = 1; $x < 9; ++$x){
+
+        switch(strlen($this->skindata)){
+            case 8192:
+            case 16384:
+                $maxX = $maxY = 8;
+
+                $width = 64;
+                $layer2Offset = 32;
+                break;
+
+            case 65536:
+                $maxX = $maxY = 16;
+
+                $width = 128;
+                $layer2Offset = 64;
+        }
+
+        $skin = substr($this->skindata, ($pos = ($width * $maxX * 4)) - 4, $pos);
+
+	for($y = 0; $y < $maxY; ++$y){
+		for($x = 1; $x < $maxX + 1; ++$x){
 			if(!isset($strArray[$y])){
 				$strArray[$y] = "";
 			}
 			// layer 1
-			$key = ((64 * $y) + 8 + $x) * 4;
+			$key = (($width * $y) + $maxX + $x) * 4;
 
 			// layer 2
-			$key2 = ((64 * $y) + 8 + $x + 32) * 4;
+			$key2 = (($width * $y) + $maxX + $x + $layer2Offset) * 4;
 			$a = ord($skin{$key2 + 3});
 
 			if($a >= 127){ // if layer 2 pixel is opaque enough, use it instead.


### PR DESCRIPTION
This pr was built on top of the #9 pr since I needed the changes to properly test this in-game.

The focus of this pr lies on supporting 128x128 skins properly, which would previously be treated like 64x64 and 64x32 skins.
To achieve this I've introduced a few variables which are declared accordingly by considering the skin data length.